### PR TITLE
Bump ansible version in the overlay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM debian:jessie-backports
+FROM debian:stretch-backports
 
 WORKDIR /ansible-overlay
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -t jessie-backports -y --force-yes install \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -t stretch-backports -y --force-yes install \
     bash \
     python2.7-minimal \
     python-virtualenv \
@@ -12,6 +12,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -t jessie-backports
 
 RUN virtualenv --system-site-packages /ansible
 RUN /ansible/bin/pip install --upgrade pip setuptools
-RUN /ansible/bin/pip install ansible
+RUN /ansible/bin/pip install ansible==2.9.0
 
 COPY . /ansible-overlay


### PR DESCRIPTION
Also move to strech, as that's what's being booted in dce-gc2

cc https://github.com/github/compute-foundation/issues/379